### PR TITLE
Switch streaming backend to SimulStreaming

### DIFF
--- a/web-app/backend/Dockerfile
+++ b/web-app/backend/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /usr/src/app
 
 # Install dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY . .

--- a/web-app/backend/api/transcription.py
+++ b/web-app/backend/api/transcription.py
@@ -106,31 +106,66 @@ async def websocket_live_transcribe(websocket: WebSocket):
         await websocket.close(code=1008, reason="Invalid token")
         return
 
-    # now proxy to whisper-livekit
+    from config.settings import get_settings
+    settings = get_settings()
     try:
-        async with websockets.connect("ws://whisper_livekit:8000/asr") as proxy_ws:
-            async def forward_client_to_proxy():
-                try:
-                    while True:
-                        data = await websocket.receive_bytes()
-                        await proxy_ws.send(data)
-                except WebSocketDisconnect:
-                    await proxy_ws.close()
+        reader, writer = await asyncio.open_connection(settings.simul_host, settings.simul_port)
 
-            async def forward_proxy_to_client():
-                try:
-                    async for msg in proxy_ws:
-                        if isinstance(msg, bytes):
-                            await websocket.send_bytes(msg)
-                        else:
-                            await websocket.send_text(msg)
-                except Exception:
-                    await websocket.close()
+        PACKET_SIZE = 65536
 
-            await asyncio.gather(
-                forward_client_to_proxy(),
-                forward_proxy_to_client(),
+        async def convert_webm_to_pcm(data: bytes) -> bytes:
+            proc = await asyncio.create_subprocess_exec(
+                'ffmpeg', '-i', 'pipe:0', '-f', 's16le', '-ac', '1', '-ar', '16000', 'pipe:1',
+                stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL
             )
+            out, _ = await proc.communicate(data)
+            return out
+
+        async def forward_client_to_server():
+            try:
+                while True:
+                    data = await websocket.receive_bytes()
+                    if len(data) == 0:
+                        writer.write_eof()
+                        await writer.drain()
+                        break
+                    pcm = await convert_webm_to_pcm(data)
+                    if pcm:
+                        writer.write(pcm)
+                        await writer.drain()
+            except WebSocketDisconnect:
+                writer.close()
+
+        async def forward_server_to_client():
+            buffer = b""
+            try:
+                while True:
+                    chunk = await reader.read(PACKET_SIZE)
+                    if not chunk:
+                        break
+                    buffer += chunk
+                    while b'\0' in buffer:
+                        packet, buffer = buffer.split(b'\0', 1)
+                        line = packet.decode('utf-8', errors='replace').strip('\n')
+                        if not line:
+                            continue
+                        parts = line.split(maxsplit=2)
+                        if len(parts) >= 3:
+                            beg = float(parts[0]) / 1000.0
+                            end = float(parts[1]) / 1000.0
+                            text = parts[2]
+                            msg = json.dumps({
+                                'lines': [{ 'beg': beg, 'end': end, 'text': text }]
+                            })
+                            await websocket.send_text(msg)
+            finally:
+                await websocket.send_text(json.dumps({'type': 'ready_to_stop'}))
+
+        await asyncio.gather(
+            forward_client_to_server(),
+            forward_server_to_client(),
+        )
     except Exception as e:
         logger.error(f"WebSocket proxy error for user {user_id}: {e}")
         await websocket.close(code=1011, reason="Proxy error")

--- a/web-app/backend/config/settings.py
+++ b/web-app/backend/config/settings.py
@@ -11,7 +11,9 @@ class Settings(BaseSettings):
     port: int = int(os.environ.get("PORT", "5001"))
 
     # Service URLs
-    audio_server_url: str = os.environ.get("AUDIO_SERVER_URL", "http://whisper_livekit:8000")
+    audio_server_url: str = os.environ.get("AUDIO_SERVER_URL", "http://simulstreaming:43007")
+    simul_host: str = os.environ.get("SIMUL_HOST", "simulstreaming")
+    simul_port: int = int(os.environ.get("SIMUL_PORT", "43007"))
     ollama_server_url: str = os.environ.get("OLLAMA_SERVER_URL", "http://summarization_service:11434")
     llm_uri: str = f"{ollama_server_url}/api/chat"
 

--- a/web-app/docker/docker-compose.yml
+++ b/web-app/docker/docker-compose.yml
@@ -13,23 +13,22 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
     depends_on:
-      whisper_livekit:
+      simulstreaming:
         condition: service_started
       summarization_service:
         condition: service_healthy
     networks:
       - auto_transcript_network
 
-  whisper_livekit:
+  simulstreaming:
     platform: linux/amd64
     build:
-      context: ./services/whisper-livekit
+      context: ./services/simulstreaming
       dockerfile: Dockerfile
     volumes:
-      - ./services/whisper-livekit:/app  # mount service code for hot reload
-      - ./services/whisper-livekit/models:/app/models  # shared model storage
+      - ./services/simulstreaming:/app
     ports:
-      - "8000:8000"  # FastAPI port
+      - "43007:43007"
     environment:
       PYTHONUNBUFFERED: 1
       CUDA_VISIBLE_DEVICES: 0

--- a/web-app/docker/services/simulstreaming/Dockerfile
+++ b/web-app/docker/services/simulstreaming/Dockerfile
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git ffmpeg python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/ufal/SimulStreaming.git /app/SimulStreaming
+WORKDIR /app/SimulStreaming
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+
+EXPOSE 43007
+
+CMD ["python", "simulstreaming_whisper_server.py", "--host", "0.0.0.0", "--port", "43007", "--model_path", "./large-v3.pt"]

--- a/web-app/docker/services/simulstreaming/README.md
+++ b/web-app/docker/services/simulstreaming/README.md
@@ -1,0 +1,5 @@
+# SimulStreaming Service
+
+This Docker image runs the [SimulStreaming](https://github.com/ufal/SimulStreaming) server which provides real time transcription over a TCP socket.
+
+The container exposes port **43007** and uses the `simulstreaming_whisper_server.py` entrypoint with the large-v3 Whisper model by default.


### PR DESCRIPTION
## Summary
- use SimulStreaming server instead of WhisperLiveToolkit
- install ffmpeg in backend image for audio decoding
- update settings with SimulStreaming host/port defaults
- implement live transcription socket client using ffmpeg for conversion
- add SimulStreaming service to docker compose

## Testing
- `python -m compileall web-app/backend`

------
https://chatgpt.com/codex/tasks/task_e_68711971e6288332a8f481c6bea10810