### PR TITLE
Add audio upload player

### DIFF
--- a/web-app/frontend/components/AudioUploadPlayer.vue
+++ b/web-app/frontend/components/AudioUploadPlayer.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, nextTick } from 'vue'
+import { Play, Pause, Upload, X } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useAudioRecording } from '@/composables/useAudioRecording'
+import { Progress } from '@/components/ui/progress'
+
+interface Props {
+  open: boolean
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'file-transcribed': []
+}>()
+
+const isOpen = ref(props.open)
+watch(() => props.open, (val) => { isOpen.value = val })
+watch(isOpen, (val) => emit('update:open', val))
+
+const fileInput = ref<HTMLInputElement>()
+const audioRef = ref<HTMLAudioElement>()
+const file = ref<File | null>(null)
+const audioUrl = ref('')
+const isPlaying = ref(false)
+const currentTime = ref(0)
+const duration = ref(0)
+const hasTranscribed = ref(false)
+const isTranscribing = ref(false)
+
+function openFileDialog() {
+  fileInput.value?.click()
+}
+
+function handleFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const f = target.files?.[0]
+  if (f) {
+    file.value = f
+    audioUrl.value = URL.createObjectURL(f)
+    // preload duration
+    nextTick(() => {
+      if (audioRef.value) {
+        audioRef.value.load()
+      }
+    })
+  }
+}
+
+function togglePlay() {
+  if (!file.value || !audioRef.value) return
+  if (!hasTranscribed.value) {
+    startTranscription()
+  }
+  if (isPlaying.value) {
+    audioRef.value.pause()
+  } else {
+    audioRef.value.play()
+  }
+  isPlaying.value = !isPlaying.value
+}
+
+function startTranscription() {
+  if (!file.value) return
+  if (isTranscribing.value) return
+  isTranscribing.value = true
+  hasTranscribed.value = true
+  const { transcribeFile } = useAudioRecording()
+  transcribeFile(file.value).finally(() => {
+    isTranscribing.value = false
+    emit('file-transcribed')
+  })
+}
+
+function updateTime() {
+  if (audioRef.value) {
+    currentTime.value = audioRef.value.currentTime
+    duration.value = audioRef.value.duration
+  }
+}
+
+function close() {
+  isOpen.value = false
+  cleanup()
+}
+
+function cleanup() {
+  if (audioUrl.value) URL.revokeObjectURL(audioUrl.value)
+  file.value = null
+  audioUrl.value = ''
+  isPlaying.value = false
+  currentTime.value = 0
+  duration.value = 0
+  hasTranscribed.value = false
+  isTranscribing.value = false
+}
+
+onBeforeUnmount(cleanup)
+</script>
+
+<template>
+  <Dialog v-model:open="isOpen">
+    <DialogContent class="max-w-md">
+      <DialogHeader>
+        <DialogTitle>Upload Audio File</DialogTitle>
+      </DialogHeader>
+      <div class="space-y-4">
+        <input ref="fileInput" type="file" accept="audio/*" class="hidden" @change="handleFileChange" />
+        <div v-if="!file">
+          <Button @click="openFileDialog" class="w-full">
+            <Upload class="h-4 w-4 mr-2" />Select Audio File
+          </Button>
+        </div>
+        <div v-else class="space-y-2">
+          <p class="text-sm break-all">{{ file.name }}</p>
+          <audio ref="audioRef" :src="audioUrl" class="hidden" @timeupdate="updateTime" @ended="isPlaying=false" />
+          <div class="flex items-center space-x-3">
+            <Button @click="togglePlay" :disabled="isTranscribing" size="icon">
+              <Play v-if="!isPlaying" class="h-4 w-4" />
+              <Pause v-else class="h-4 w-4" />
+            </Button>
+            <Progress :model-value="duration ? (currentTime / duration) * 100 : 0" class="flex-1" />
+            <span class="text-xs font-mono w-16 text-right">{{ currentTime.toFixed(1) }}s</span>
+          </div>
+          <div v-if="isTranscribing" class="text-xs text-muted-foreground">Uploading & transcribing...</div>
+        </div>
+        <div class="flex justify-end">
+          <Button variant="ghost" size="sm" @click="close">
+            <X class="h-3 w-3 mr-1" />Close
+          </Button>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/web-app/frontend/lib/utils.ts
+++ b/web-app/frontend/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]) {
+  return classes.filter(Boolean).join(' ')
+}

--- a/web-app/frontend/pages/dashboard.vue
+++ b/web-app/frontend/pages/dashboard.vue
@@ -11,7 +11,8 @@ import ConfigPanel from '@/components/ConfigPanel.vue'
 import HeaderBar from '@/components/HeaderBar.vue'
 import TranscriptionPanel from '@/components/TranscriptionPanel.vue'
 import LiveIncidentPanel from '@/components/LiveIncidentPanel.vue'
-import { watch, computed } from 'vue'
+import AudioUploadPlayer from '@/components/AudioUploadPlayer.vue'
+import { watch, computed, ref } from 'vue'
 
 definePageMeta({
   middleware: 'auth'
@@ -48,8 +49,8 @@ const {
 } = useSummaryGeneration(transcriptionSegments)
 
 
-// File upload
-const audioFileInput = ref<HTMLInputElement>()
+// Upload player state
+const isUploadPlayerOpen = ref(false)
 
 // Configuration state
 const isConfigPanelOpen = ref(false)
@@ -172,23 +173,7 @@ const summaries = computed(() => transcriptionStore.getSummaries)
 
 // Methods
 async function uploadRecording() {
-  audioFileInput.value?.click()
-}
-
-async function handleFileUpload(event: Event) {
-  const target = event.target as HTMLInputElement
-  const file = target.files?.[0]
-
-  if (file) {
-    try {
-      await transcribeFile(file)
-    } catch (error) {
-      console.error('File upload failed:', error)
-    }
-
-    // Reset file input
-    target.value = ''
-  }
+  isUploadPlayerOpen.value = true
 }
 
 async function handleStartRecording() {
@@ -434,14 +419,9 @@ useHead({
       </Button>
     </div>
 
-    <!-- Hidden file input -->
-    <input
-      ref="audioFileInput"
-      type="file"
-      accept="audio/*"
-      class="hidden"
-      @change="handleFileUpload"
-    />
+
+    <!-- Upload Player -->
+    <AudioUploadPlayer v-model:open="isUploadPlayerOpen" />
 
     <!-- Prompt Configuration Panel -->
     <ConfigPanel


### PR DESCRIPTION
## Summary
- add audio upload dialog for playback-transcription
- integrate new player into dashboard
- expose a simple `cn` helper in frontend

## Testing
- `npm run build` *(fails: Could not initialize provider googleicons, google, bunny, fontshare, fontsource)*

------
https://chatgpt.com/codex/tasks/task_e_6878d4a368f08332857305a4e5c48682