### PR TITLE
feat: add custom prompt support for whisper transcription

### DIFF
--- a/web-app/backend/api/transcription.py
+++ b/web-app/backend/api/transcription.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, File, UploadFile, HTTPException, Depends
+from fastapi import APIRouter, File, UploadFile, HTTPException, Depends, Form
 from typing import Dict, List, Optional
 import json
 import logging
@@ -21,6 +21,7 @@ transcription_history = {}
 @router.post("/transcribe", response_model=TranscriptionResponse)
 async def transcribe_audio(
     file: UploadFile = File(...),
+    prompt: Optional[str] = Form(None),
     token_data: TokenData = Depends(get_token_data)
 ):
     """Transcribe audio from an uploaded file"""
@@ -28,8 +29,13 @@ async def transcribe_audio(
         # Read file content
         file_content = await file.read()
 
-        # Call the transcription service
-        segments = await transcribe_audio_file(file_content, file.filename, file.content_type)
+        # Call the transcription service with optional prompt
+        segments = await transcribe_audio_file(
+            file_content,
+            file.filename,
+            file.content_type,
+            prompt,
+        )
         print("Transcription Segments:", segments)
 
         # Extract text for processing

--- a/web-app/backend/services/whisper/worker.py
+++ b/web-app/backend/services/whisper/worker.py
@@ -16,7 +16,12 @@ async def main() -> None:
         data = job["data"]
         try:
             content = base64.b64decode(data["file_content"])
-            segments = await _send_to_whisper(content, data["filename"], data["content_type"])
+            segments = await _send_to_whisper(
+                content,
+                data["filename"],
+                data["content_type"],
+                data.get("prompt"),
+            )
             await queue.send_result(job["id"], [seg.dict() for seg in segments])
         except Exception as e:
             logger.error(f"Whisper worker error: {e}")

--- a/web-app/frontend/components/AudioSimulationPlayer.vue
+++ b/web-app/frontend/components/AudioSimulationPlayer.vue
@@ -12,6 +12,10 @@ const emit = defineEmits<{
   'segments-updated': [segments: any[]]
 }>()
 
+const props = defineProps<{
+  customWhisperPrompt?: string
+}>()
+
 const authStore = useAuthStore()
 
 const audioRef = ref<HTMLAudioElement>()
@@ -218,6 +222,9 @@ async function sendChunkToBackend(chunk: { blob: Blob; startTime: number; endTim
     
     const formData = new FormData()
     formData.append('file', chunk.blob, `simulation_chunk_${chunkIndex}.wav`)
+    if (props.customWhisperPrompt) {
+      formData.append('prompt', props.customWhisperPrompt)
+    }
     
     const baseUrl = import.meta.env.DEV ? 'http://localhost:5002' : ''
     const response = await fetch(`${baseUrl}/transcribe`, {

--- a/web-app/frontend/components/AudioUploadPlayer.vue
+++ b/web-app/frontend/components/AudioUploadPlayer.vue
@@ -7,6 +7,7 @@ import AudioSimulationPlayer from './AudioSimulationPlayer.vue'
 interface Props {
   isRecording: boolean
   isSimulateMode: boolean
+  customWhisperPrompt?: string
 }
 
 const props = defineProps<Props>()
@@ -38,5 +39,9 @@ watch(isSimulating, (val) => {
     <Label for="simulate-mode">Simulate</Label>
   </div>
 
-  <AudioSimulationPlayer v-if="isSimulating" @close="isSimulating = false" />
+  <AudioSimulationPlayer
+    v-if="isSimulating"
+    @close="isSimulating = false"
+    :custom-whisper-prompt="props.customWhisperPrompt"
+  />
 </template>

--- a/web-app/frontend/components/TranscriptionPanel.vue
+++ b/web-app/frontend/components/TranscriptionPanel.vue
@@ -36,7 +36,6 @@ interface Props {
   recordingState: RecordingState
   sidebarWidth?: number
   isSimulateMode?: boolean
-  customNerPrompt?: string
 }
 
 const props = defineProps<Props>()
@@ -82,7 +81,7 @@ watch(
       // Only process non-live segments that haven't been processed
       if (!segment.isLive && segment.text.trim() && getProcessingStatus(index) === 'raw') {
         console.log(`[TranscriptionPanel] Processing finalized segment ${index}:`, segment.text.substring(0, 50) + '...')
-        processTranscriptionBlock(segment.text, index, props.customNerPrompt)
+        processTranscriptionBlock(segment.text, index)
       }
     })
   },

--- a/web-app/frontend/composables/audio-recording/index.ts
+++ b/web-app/frontend/composables/audio-recording/index.ts
@@ -19,7 +19,7 @@ interface RecordingVariables {
   chunkCount: number;
 }
 
-export const useAudioRecording = (customNerPrompt?: Ref<string>) => {
+export const useAudioRecording = (customWhisperPrompt?: Ref<string>) => {
   const state = ref<RecordingState>({
     isRecording: false,
     isProcessing: false,
@@ -73,7 +73,7 @@ export const useAudioRecording = (customNerPrompt?: Ref<string>) => {
 
     try {
       console.log(`[Auto-Processing] 🚀 Starting processing for block ${segmentIndex}`);
-      await processAdvancedBlock(segment.text, segmentIndex, customNerPrompt?.value);
+      await processAdvancedBlock(segment.text, segmentIndex);
       console.log(`[Auto-Processing] ✅ Block ${segmentIndex} processed successfully`);
     } catch (error) {
       console.error(`[Auto-Processing] ❌ Block ${segmentIndex} processing failed:`, error);
@@ -87,6 +87,9 @@ export const useAudioRecording = (customNerPrompt?: Ref<string>) => {
 
       const formData = new FormData();
       formData.append('file', audioBlob, 'audio.webm');
+      if (customWhisperPrompt?.value) {
+        formData.append('prompt', customWhisperPrompt.value);
+      }
 
       const baseUrl = process.env.NODE_ENV === 'development' ? 'http://localhost:5002' : '';
       const response = await fetch(`${baseUrl}/transcribe`, {

--- a/web-app/frontend/composables/useAdvancedTextProcessing.ts
+++ b/web-app/frontend/composables/useAdvancedTextProcessing.ts
@@ -15,10 +15,9 @@ const processedBlocks = ref<Record<number, ProcessedBlock>>({})
 
 export const useAdvancedTextProcessing = () => {
 
-  const processTranscriptionBlock = async (text: string, segmentIndex: number, customNerPrompt?: string): Promise<ProcessedBlock> => {
+  const processTranscriptionBlock = async (text: string, segmentIndex: number): Promise<ProcessedBlock> => {
     try {
       console.log(`[AdvancedTextProcessing] 🚀 Starting processing for block ${segmentIndex}:`, text.substring(0, 50) + '...')
-      console.log(`[AdvancedTextProcessing] 🎨 Using custom NER prompt:`, customNerPrompt ? 'Yes' : 'No (using default)')
 
       // Mark as processing
       const processingBlock: ProcessedBlock = {
@@ -37,8 +36,7 @@ export const useAdvancedTextProcessing = () => {
       console.log(`[AdvancedTextProcessing] 📡 Making API call to /process-block for block ${segmentIndex}`)
 
       const response = await $api.post('/process-block', {
-        text: text,
-        ner_prompt: customNerPrompt || ''
+        text: text
       })
 
       console.log(`[AdvancedTextProcessing] ✅ API response for block ${segmentIndex}:`, response.data)

--- a/web-app/frontend/pages/dashboard.vue
+++ b/web-app/frontend/pages/dashboard.vue
@@ -67,7 +67,7 @@ const isConfigPanelOpen = ref(false)
 const isHealthModalOpen = ref(false)
 const isNerLegendModalOpen = ref(false)
 const customPrompt = ref('Extract pending items and emergencies from transcription. Focus on safety issues and required actions.')
-const customNerPrompt = ref('')
+const customWhisperPrompt = ref('')
 const customFormatTemplate = ref('')
 const autoReportEnabled = ref(false) // UI state only, copies from composable
 const autoReportIntervalValue = ref(30)
@@ -82,7 +82,7 @@ const {
   transcribeFile,
   clearTranscription,
   updateSegment
-} = useAudioRecording(customNerPrompt)
+} = useAudioRecording(customWhisperPrompt)
 
 const {
   state: summaryState,
@@ -114,7 +114,7 @@ onMounted(async () => {
 
   if (process.client) {
     const savedPrompt             = localStorage.getItem('atlas-custom-prompt')
-    const savedNerPrompt          = localStorage.getItem('atlas-custom-ner-prompt')
+    const savedWhisperPrompt      = localStorage.getItem('atlas-custom-whisper-prompt')
     const savedFormatTemplate     = localStorage.getItem('atlas-custom-format-template')
     const savedAutoReportEnabled  = localStorage.getItem('atlas-auto-report-enabled')
     const savedAutoReportInterval = localStorage.getItem('atlas-auto-report-interval')
@@ -122,8 +122,8 @@ onMounted(async () => {
     if (savedPrompt) {
       customPrompt.value = savedPrompt
     }
-    if (savedNerPrompt) {
-      customNerPrompt.value = savedNerPrompt
+    if (savedWhisperPrompt) {
+      customWhisperPrompt.value = savedWhisperPrompt
     }
     if (savedFormatTemplate) {
       customFormatTemplate.value = savedFormatTemplate
@@ -157,9 +157,9 @@ watch(customPrompt, (newValue) => {
   }
 })
 
-watch(customNerPrompt, (newValue) => {
+watch(customWhisperPrompt, (newValue) => {
   if (process.client) {
-    localStorage.setItem('atlas-custom-ner-prompt', newValue)
+    localStorage.setItem('atlas-custom-whisper-prompt', newValue)
   }
 })
 
@@ -290,7 +290,7 @@ function openNerLegendModal() {
 
 function resetConfig() {
   customPrompt.value = 'Extract pending items and emergencies from transcription. Focus on safety issues and required actions.'
-  customNerPrompt.value = ''
+  customWhisperPrompt.value = ''
   customFormatTemplate.value = ''
   autoReportEnabled.value = false
   autoReportIntervalValue.value = 30
@@ -452,14 +452,12 @@ useHead({
             :recording-state="transcriptionPanelRecordingState"
             :sidebar-width="sidebarWidth"
             :is-simulate-mode="isSimulateMode"
-            :custom-ner-prompt="customNerPrompt"
             @update-segment="handleUpdateSegment"
             @update:is-simulate-mode="isSimulateMode = $event"
             @start-recording="handleToggleRecording"
             @stop-recording="handleToggleRecording"
             @toggle-recording="handleToggleRecording"
             @clear-transcription="handleClearTranscription"
-            @segments-updated="handleSimulationSegmentsUpdated"
             @open-ner-legend="openNerLegendModal"
             class="h-full"
           />
@@ -489,10 +487,11 @@ useHead({
     </div>
 
     <!-- Floating Audio Simulation Player -->
-    <AudioSimulationPlayer 
-      v-if="isSimulateMode && backendHealthy" 
+    <AudioSimulationPlayer
+      v-if="isSimulateMode && backendHealthy"
       @close="isSimulateMode = false"
       @segments-updated="handleSimulationSegmentsUpdated"
+      :custom-whisper-prompt="customWhisperPrompt"
     />
 
     <!-- Health Status Modal -->
@@ -509,7 +508,7 @@ useHead({
     <ConfigPanel
       v-model:is-open="isConfigPanelOpen"
       v-model:custom-summary-prompt="customPrompt"
-      v-model:custom-ner-prompt="customNerPrompt"
+      v-model:custom-whisper-prompt="customWhisperPrompt"
       v-model:custom-format-template="customFormatTemplate"
       @apply="handleApplySettings"
       @reset="resetConfig"

--- a/web-app/frontend/plugins/api.client.ts
+++ b/web-app/frontend/plugins/api.client.ts
@@ -46,16 +46,19 @@ export default defineNuxtPlugin(() => {
   )
 
   // Transcription API methods
-  const transcribeAudio = async (audioBlob: Blob) => {
+  const transcribeAudio = async (audioBlob: Blob, prompt?: string) => {
     const formData = new FormData()
     formData.append('file', audioBlob, 'audio.webm')
-    
+    if (prompt) {
+      formData.append('prompt', prompt)
+    }
+
     const response = await api.post('/transcribe', formData, {
       headers: {
         'Content-Type': 'multipart/form-data'
       }
     })
-    
+
     return response.data
   }
 


### PR DESCRIPTION
## Summary
- allow `/transcribe` API to accept optional prompt forwarded through worker and whisper service
- enable prompt-conditioned decoding in whisper service using `prompt_ids`
- send custom whisper prompt from frontend audio recording and simulation flows
- rename frontend NER prompt inputs to "Whisper Prompt" and drop unused NER prompt plumbing

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688dc73ce390833280c9a89083d8ffba